### PR TITLE
In database.yml, remove unnecessary 'host' option from development and t...

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -2,14 +2,12 @@ development:
   encoding: utf8
   adapter: postgresql
   database: soapbox_development
-  host: 127.0.0.1
   min_messages: warning
 
 test:
   encoding: utf8
   adapter: postgresql
   database: soapbox_test
-  host: 127.0.0.1
   min_messages: warning
 
  # development:


### PR DESCRIPTION
...est. On Ubuntu, by default, Postgres requires a password when connecting to 127.0.0.1 but not when using the default Unix sockets.
