### PR TITLE
rename Meeting#can_give_kudo? to given_kudo?

### DIFF
--- a/app/models/meeting.rb
+++ b/app/models/meeting.rb
@@ -75,14 +75,14 @@ class Meeting < ActiveRecord::Base
   end
 
   def kudos_available?(user)
-    kudos_open? && can_give_kudo?(user)
+    kudos_open? && !given_kudo?(user)
   end
 
   def give_kudo(topic, user)
     Kudo.create!(topic: topic, user: user)
   end
 
-  def can_give_kudo?(user)
-    topics.none?{ |t| t.given_kudo?(user) }
+  def given_kudo?(user)
+    topics.any?{ |t| t.given_kudo?(user) }
   end
 end

--- a/spec/models/meeting_spec.rb
+++ b/spec/models/meeting_spec.rb
@@ -66,13 +66,13 @@ describe Meeting do
     context 'when the user has given a kudo' do
       let(:topics) { [topic_with_kudo] }
 
-      specify { meeting.can_give_kudo?(user).should be_false }
+      specify { meeting.given_kudo?(user).should be_true }
     end
 
     context 'when the user has not given a kudo' do
       let(:topics) { [topic_without_kudo] }
 
-      specify { meeting.can_give_kudo?(user).should be_true }
+      specify { meeting.given_kudo?(user).should be_false }
     end
 
   end


### PR DESCRIPTION
...since it does not actually check whether they can currently give a kudo (which depends on whether open_kudos! has been run), and to make it parallel to Topic#given_kudo?
